### PR TITLE
Fix deprecated dash-separated names in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,10 @@
 [metadata]
 name = sarif_om
 author = Microsoft Corporation
-author-email = v-lgold@microsoft.com
+author_email = v-lgold@microsoft.com
 summary = Classes implementing the SARIF 2.1.0 object model.
-home-page = https://github.com/microsoft/sarif-python-om
-description-file = README.rst
+home_page = https://github.com/microsoft/sarif-python-om
+description_file = README.rst
 license = MIT
 classifier =
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
Replace `author-email`, `home-page`, and `description-file` with `author_email`, `home_page`, and `description_file`, respectively.

Fixes:

```
  !!
    easy_install.initialize_options(self)
  /usr/lib/python3.12/site-packages/setuptools/dist.py:476: SetuptoolsDeprecationWarning: Invalid dash-separated options
  !!

          ********************************************************************************
          Usage of dash-separated 'author-email' will not be supported in future
          versions. Please use the underscore name 'author_email' instead.

          By 2024-Sep-26, you need to update your project and remove deprecated calls
          or your builds will no longer be supported.

          See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
          ********************************************************************************

  !!
    opt = self.warn_dash_deprecation(opt, section)
  /usr/lib/python3.12/site-packages/setuptools/dist.py:476: SetuptoolsDeprecationWarning: Invalid dash-separated options
  !!

          ********************************************************************************
          Usage of dash-separated 'home-page' will not be supported in future
          versions. Please use the underscore name 'home_page' instead.

          By 2024-Sep-26, you need to update your project and remove deprecated calls
          or your builds will no longer be supported.

          See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
          ********************************************************************************

  !!
    opt = self.warn_dash_deprecation(opt, section)
  /usr/lib/python3.12/site-packages/setuptools/dist.py:476: SetuptoolsDeprecationWarning: Invalid dash-separated options
  !!

          ********************************************************************************
          Usage of dash-separated 'description-file' will not be supported in future
          versions. Please use the underscore name 'description_file' instead.

          By 2024-Sep-26, you need to update your project and remove deprecated calls
          or your builds will no longer be supported.

          See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
          ********************************************************************************
```